### PR TITLE
Remove a dependency that can be addressed in the upstream than tensorflow_ros

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,6 @@
   <build_export_depend>python</build_export_depend>
 
   <build_depend>python-pip</build_depend> <!-- optional -->
-  <build_depend>swig</build_depend>
 
   <depend>python-tensorflow-pip</depend> <!-- optional -->
   <depend>tensorflow_catkin</depend> <!-- optional -->


### PR DESCRIPTION
Addressing https://github.com/tradr-project/tensorflow_ros/pull/7#commitcomment-29363522

Technically I could just reset the commit that added `swig` instead of adding another commit like in this PR to remove it, but I prefer keeping the history :) But it's up to the maintainers.

(Also on a separate note, would you mind opening PRs for any change in the future instead of directly committing? That way people subscribing get notifications (we keep our fork version of your repo and want to sync as much, so getting notified is kind of crucial to us), and having PR pages makes it much easier to reference to the decision made and keep track of it. In the end it's up to the maintainers though. Thanks.)